### PR TITLE
update deprecated ipc require

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,4 +1,4 @@
-var ipc = require('ipc')
+var ipc = require('electron').ipcMain
 
 function Server (webContents) {
   this.methods = {}


### PR DESCRIPTION
Hi!

Got this deprecation warning when working on a project that used this module:

```
(electron) ipc module is deprecated. Use require("electron").ipcMain instead.
```

This PR changes the `require('ipc')` line accordingly.
