### PR TITLE
update ipc modules

### DIFF
--- a/client.js
+++ b/client.js
@@ -1,9 +1,9 @@
 var events = require('events')
-var ipc = require('ipc')
+var ipcRenderer = require('electron').ipcRenderer
 
 function Client () {
   this.requests = {}
-  this.remoteEventEmitter = ipc
+  this.remoteEventEmitter = ipcRenderer
   this.localEventEmitter = new events.EventEmitter()
   this._responseMessageHandler = responseMessageHandler.bind(this)
   this.remoteEventEmitter.on('response-message', this._responseMessageHandler)

--- a/server.js
+++ b/server.js
@@ -1,12 +1,11 @@
-var ipc = require('electron').ipcMain
+var ipcMain = require('electron').ipcMain
 
 function Server (webContents) {
   this.methods = {}
   this.webContents = webContents
 
-  // ipc.removeAllListeners('request-message')
   this._requestMessageHandler = requestMessageHandler.bind(this)
-  ipc.on('request-message', this._requestMessageHandler)
+  ipcMain.on('request-message', this._requestMessageHandler)
 }
 
 Server.prototype.send = function (action, body) {
@@ -32,7 +31,7 @@ Server.prototype.on = function (action, callback) {
 Server.prototype.destroy = function () {
   this.methods = {}
   this.webContents = undefined
-  ipc.removeListener('request-message', this._requestMessageHandler)
+  ipcMain.removeListener('request-message', this._requestMessageHandler)
 }
 
 function requestMessageHandler (ev, data) {


### PR DESCRIPTION
Okay, this should cover all uses of the deprecated `ipc` module. Also switched to using their full module names to reduce potential confusion.

> #1
